### PR TITLE
Add a stat-counter to each page of the dashboard

### DIFF
--- a/site-config.yml
+++ b/site-config.yml
@@ -1,3 +1,22 @@
 ---
 hub: "CDCgov/covid19-forecast-hub/"
 title: "COVID-19 Forecast Hub Dashboard"
+html:
+  include-after-body:
+    - text: |
+        <!-- Default Statcounter code for CFA covid hub dashboard https://reichlab.io/covidhub-dashboard/ -->
+        <script type="text/javascript">
+        var sc_project=13093552; 
+        var sc_invisible=1; 
+        var sc_security="447e9a87"; 
+        </script>
+        <script type="text/javascript"
+        src="https://www.statcounter.com/counter/counter.js"
+        async></script>
+        <noscript><div class="statcounter"><a title="Web Analytics"
+        href="https://statcounter.com/" target="_blank"><img
+        class="statcounter"
+        src="https://c.statcounter.com/13093552/0/447e9a87/1/"
+        alt="Web Analytics"
+        referrerPolicy="no-referrer-when-downgrade"></a></div></noscript>
+        <!-- End of Statcounter Code -->


### PR DESCRIPTION
Closes #2 

Since the dashboard builder will merge site-config.yml with the default quarto config file,
we can use quarto's include-after-body directive to inject a javascript snippet on each each page.
https://quarto.org/docs/output-formats/html-basics.html#includes