### PR TITLE
remove model_tasks_idx key

### DIFF
--- a/predtimechart-config.yml
+++ b/predtimechart-config.yml
@@ -1,6 +1,5 @@
 ---
 rounds_idx: 0
-model_tasks_idx: 0
 reference_date_col_name: 'reference_date'
 target_date_col_name: 'target_end_date'
 horizon_col_name: 'horizon'


### PR DESCRIPTION
> [!IMPORTANT]
>
> Please **rebase** this PR so that the `[ci skip]` notice remains in the commit message


This removes model_tasks_idx key from the predtimchart config file so that multiple targets are supported.